### PR TITLE
Fix code scanning alert no. 4: Time-of-check time-of-use race condition

### DIFF
--- a/solutions/java/src/parkinglot/Level.java
+++ b/solutions/java/src/parkinglot/Level.java
@@ -38,6 +38,8 @@ public class Level {
                     spot.parkVehicle(vehicle);
                     return true;
                 }
+                    return true;
+                }
             }
         }
         return false;

--- a/solutions/java/src/parkinglot/Level.java
+++ b/solutions/java/src/parkinglot/Level.java
@@ -31,11 +31,13 @@ public class Level {
         }
     }
 
-    public synchronized boolean parkVehicle(Vehicle vehicle) {
+    public boolean parkVehicle(Vehicle vehicle) {
         for (ParkingSpot spot : parkingSpots) {
-            if (spot.isAvailable() && spot.getVehicleType() == vehicle.getType()) {
-                spot.parkVehicle(vehicle);
-                return true;
+            synchronized (spot) {
+                if (spot.isAvailable() && spot.getVehicleType() == vehicle.getType()) {
+                    spot.parkVehicle(vehicle);
+                    return true;
+                }
             }
         }
         return false;


### PR DESCRIPTION
Fixes [https://github.com/dsp-testing/alona-awesome-low-level-design/security/code-scanning/4](https://github.com/dsp-testing/alona-awesome-low-level-design/security/code-scanning/4)

To fix the time-of-check time-of-use race condition in the `parkVehicle` method, we need to synchronize the check and the action on the `ParkingSpot` object. This will ensure that no other thread can modify the state of the parking spot between the check and the action.

- We will modify the `parkVehicle` method to synchronize on each `ParkingSpot` object when checking its availability and parking the vehicle.
- This change will be made in the `solutions/java/src/parkinglot/Level.java` file, specifically in the `parkVehicle` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
